### PR TITLE
Cut production bundle size in half with Zephyr

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,2 +1,27 @@
-<!doctype html><html lang="en" data-framework="purescript"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>PureScript • TodoMVC</title><link rel="stylesheet" href="/base.0a895d42.css"><link rel="stylesheet" href="/todomvc-app-css.a04e8b12.css"><style>body{width:auto}.todomvc-wrapper{visibility:visible!important}</style></head><body> <div id="app"></div> <footer class="info"> <p>Double-click to edit a todo</p> <p>Created by <a href="http://github.com/f-f">f-f</a></p> <p>Part of <a href="http://todomvc.com">TodoMVC</a></p> </footer> <script src="/purescript-react-basic-todomvc.7c7eff0e.js"></script>
-</body></html>
+<!doctype html>
+<html lang="en" data-framework="purescript">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>PureScript • TodoMVC</title>
+  <link rel="stylesheet" href="node_modules/todomvc-common/base.css">
+  <link rel="stylesheet" href="node_modules/todomvc-app-css/index.css">
+  <style>
+    body {
+      width: auto;
+    }
+    .todomvc-wrapper {
+      visibility: visible !important;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="app"></div>
+  <footer class="info">
+    <p>Double-click to edit a todo</p>
+    <p>Created by <a href="http://github.com/f-f">f-f</a></p>
+    <p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
+  </footer>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 
 import createReactClass from 'create-react-class';
 React.createClass = createReactClass;
-var App = require('./output/Todo.App');
+var App = require('./dce-output/Todo.App');
 
 function main() {
   const myComponent = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,30 +14,30 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
-      "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.6.tgz",
+      "integrity": "sha512-5QPTrNen2bm7RBc7dsOmcA5hbrS4O2Vhmk5XOL4zWW/zD/hV0iinpefDlkm+tBBy8kDtFaaeEvmAqt+nURAV2g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.9.1",
+        "browserslist": "^4.11.1",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       }
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
+        "@babel/generator": "^7.9.6",
         "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
+        "@babel/helpers": "^7.9.6",
+        "@babel/parser": "^7.9.6",
         "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -66,12 +66,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.5",
+        "@babel/types": "^7.9.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -126,29 +126,29 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-      "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.9.6.tgz",
+      "integrity": "sha512-x2Nvu0igO0ejXzx09B/1fGBxY9NXQlBW2kZsSxCJft+KHN8t9XWzIvFxtPHnBOAXpVsdxZKZFbRUC8TsNKajMw==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.6",
-        "browserslist": "^4.9.1",
+        "@babel/compat-data": "^7.9.6",
+        "browserslist": "^4.11.1",
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz",
-      "integrity": "sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
+      "integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-replace-supers": "^7.9.6",
         "@babel/helper-split-export-declaration": "^7.8.3"
       }
     },
@@ -284,15 +284,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -333,14 +333,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
       }
     },
     "@babel/highlight": {
@@ -355,9 +355,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -412,9 +412,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
-      "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz",
+      "integrity": "sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -710,38 +710,38 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
-      "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.6.tgz",
+      "integrity": "sha512-zoT0kgC3EixAyIAU+9vfaUVKTv9IxBDSabgHoUCBP6FqEJ+iNiN7ip7NBKcYqbfUDfuC2mFCbM7vbu4qJgOnDw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-      "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
+      "integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
-      "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.6.tgz",
+      "integrity": "sha512-NW5XQuW3N2tTHim8e1b7qGy7s0kZ2OH3m5octc49K1SdAKGxYxeIx7hiIz05kS1R2R+hOWcsr1eYwcGhrdHsrg==",
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.8.3",
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -801,6 +801,15 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
+      "integrity": "sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-transform-react-jsx": {
       "version": "7.9.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.4.tgz",
@@ -809,6 +818,37 @@
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.9.0",
         "@babel/helper-builder-react-jsx-experimental": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.9.0.tgz",
+      "integrity": "sha512-tK8hWKrQncVvrhvtOiPpKrQjfNX3DtkNLSX4ObuGcpS9p0QrGetKmlySIGR07y48Zft8WVgPakqd/bk46JrMSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx-experimental": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.9.0.tgz",
+      "integrity": "sha512-K2ObbWPKT7KUTAoyjCsFilOkEgMvFG+y0FqOl6Lezd0/13kMkkjHskVsZvblRPj1PHA44PrToaZANrryppzTvQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.9.0.tgz",
+      "integrity": "sha512-K6m3LlSnTSfRkM6FcRk8saNEeaeyG5k7AVkBU2bZK3+1zdkSED3qNdsWrUgQBeTVD2Tp3VMmerxVO2yM5iITmw==",
+      "dev": true,
+      "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-jsx": "^7.8.3"
       }
@@ -879,12 +919,12 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz",
-      "integrity": "sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz",
+      "integrity": "sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-create-class-features-plugin": "^7.9.6",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-typescript": "^7.8.3"
       }
@@ -900,13 +940,13 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
-      "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
+      "integrity": "sha512-0gQJ9RTzO0heXOhzftog+a/WyOuqMrAIugVYxMYf83gh1CQaQDjMtsOpqOwXyDL/5JcWsrCm8l4ju8QC97O7EQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.9.0",
-        "@babel/helper-compilation-targets": "^7.8.7",
+        "@babel/compat-data": "^7.9.6",
+        "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -914,7 +954,7 @@
         "@babel/plugin-proposal-json-strings": "^7.8.3",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-proposal-numeric-separator": "^7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.6",
         "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.9.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -941,9 +981,9 @@
         "@babel/plugin-transform-function-name": "^7.8.3",
         "@babel/plugin-transform-literals": "^7.8.3",
         "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-        "@babel/plugin-transform-modules-amd": "^7.9.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+        "@babel/plugin-transform-modules-amd": "^7.9.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.9.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.9.6",
         "@babel/plugin-transform-modules-umd": "^7.9.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
         "@babel/plugin-transform-new-target": "^7.8.3",
@@ -959,8 +999,8 @@
         "@babel/plugin-transform-typeof-symbol": "^7.8.4",
         "@babel/plugin-transform-unicode-regex": "^7.8.3",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.9.5",
-        "browserslist": "^4.9.1",
+        "@babel/types": "^7.9.6",
+        "browserslist": "^4.11.1",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
         "levenary": "^1.1.1",
@@ -980,10 +1020,24 @@
         "esutils": "^2.0.2"
       }
     },
+    "@babel/preset-react": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.9.4.tgz",
+      "integrity": "sha512-AxylVB3FXeOTQXNXyiuAQJSvss62FEotbX2Pzx3K/7c+MKJMdSg6Ose6QYllkdCFA8EInCJVw7M/o5QbLuA4ZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-transform-react-display-name": "^7.8.3",
+        "@babel/plugin-transform-react-jsx": "^7.9.4",
+        "@babel/plugin-transform-react-jsx-development": "^7.9.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.9.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.9.0"
+      }
+    },
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -1001,26 +1055,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.5",
+        "@babel/generator": "^7.9.6",
         "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.5",
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+      "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
@@ -1029,9 +1083,9 @@
       }
     },
     "@iarna/toml": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
-      "integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
     "@nodelib/fs.scandir": {
@@ -1061,21 +1115,21 @@
       }
     },
     "@parcel/babel-ast-utils": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-OKL4r1E8RJX65dgYWbON6N8PDZCgJEpUQFFcjeCPG1hlqBAEwX5UewJlZtzUQ5LrnkzzRw3EcgOhjGc0OecCOA==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-U91fem2mldqyR+3hm79ort8Ofj5rKdggzIy3gRS17UmZD19dBz9J+22vGEMMt5K6hs7H6RAk8aGVcDxAad9MVg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/babel-preset-env": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-ysvHP5OlloEy8W534seGv8iz6PYMFy6GNBmeuXo7ijtis4O0lEfVi166oXnANsrfIs8Q/kU77I3f4PLKEcx6XQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-Cb94/YY+/VoAZ++a59+qt68xZbsiaNB4qT69PPKPOx17fnRcwJ/Ws3X6XjsiyklErsDgWVB+7jThKniHfdATIQ==",
       "dev": true,
       "requires": {
         "@babel/preset-env": "^7.4.0",
@@ -1083,9 +1137,9 @@
       }
     },
     "@parcel/babylon-walk": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/babylon-walk/-/babylon-walk-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-y0h3JQ3Ezh6Rro+tWuDi2gKOTeAGgEbZUZC9gsKD1+nFsw876kIi2xIjLoUB3Txg2xWuUiW/49vWJOBPmSfzXA==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/babylon-walk/-/babylon-walk-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-IJjmVMGRweThE6JKGi3MXiexrdqi9L9KCFnIDhtYB1cMm8mPAtAk+4GwH2AA2QraqIbCafIc4UHBWZ8fleE/WQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
@@ -1093,30 +1147,30 @@
       }
     },
     "@parcel/bundler-default": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-oj7mQ4eKaFMaGqWZq8smzzb4nF0Wi3fLWWlMe/mFmeXHC4tmCUTJQ5xQA4Y8+GPu+QLvVEbhlb5axcfx/YwwcQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-pRmIKduF9tofieZiABpOJrJsAsqlCKW1TpASyZdCdILYJ9Ojv6Aq9u+gBRcfqRl4xx1BgQV9HHkaOK3W903gSw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-JxAdQeAx1IHPtANoLJdACakx+lQmUTQncSrXqAycVEASfz3b8BxHXBZrYAZsQfqG3QIMEcNWvtClynOqGXKKXA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-B5gxlHNYEwtwmiEy5EvhWeBDbImmndwluqjhe+auwzETiqla5vnNWO0pgNKflCljUymdD1N5x+/fLE1BH2TWWg==",
       "dev": true,
       "requires": {
-        "@parcel/logger": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-qXGmjy8+T9onyZOODPdh9S8Iz8oA/UIZys2o1vubZnIojzttUGGUxoY6l667z/81pefEedk9tbEgCnLEgDL85g==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-HoLZzpqLxp8CNhSY8rGq3Aea6sdMS9g+rg8dTn0z3Pqd06doD2rc9tAruZ4W+ueJTjJasAdOV1ORgw7kRhXC1A==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -1124,70 +1178,72 @@
       }
     },
     "@parcel/config-default": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-E/pIxgrGcDaZBu9DrvAIVFO3TucjOBMNFfhrSVjrzReUXNTtlNI6vcwPDxx+DajBVv4ck1mwlG6w9CrG2+tXtg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-3VFl/KRZxQAOlJP907UD5btNAdBQBt2q1qqDwI/RFXFB3TRaX+YUeZihx081aQF6RmTmgIgsOJQB/eNn0f2fSA==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.0.0-nightly.214+52fd6741",
-        "@parcel/namer-default": "2.0.0-nightly.214+52fd6741",
-        "@parcel/optimizer-cssnano": "2.0.0-nightly.214+52fd6741",
-        "@parcel/optimizer-data-url": "2.0.0-nightly.214+52fd6741",
-        "@parcel/optimizer-htmlnano": "2.0.0-nightly.214+52fd6741",
-        "@parcel/optimizer-terser": "2.0.0-nightly.214+52fd6741",
-        "@parcel/packager-css": "2.0.0-nightly.214+52fd6741",
-        "@parcel/packager-html": "2.0.0-nightly.214+52fd6741",
-        "@parcel/packager-js": "2.0.0-nightly.214+52fd6741",
-        "@parcel/packager-raw": "2.0.0-nightly.214+52fd6741",
-        "@parcel/packager-ts": "2.0.0-nightly.214+52fd6741",
-        "@parcel/reporter-bundle-analyzer": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/reporter-cli": "2.0.0-nightly.214+52fd6741",
-        "@parcel/reporter-dev-server": "2.0.0-nightly.214+52fd6741",
-        "@parcel/resolver-default": "2.0.0-nightly.214+52fd6741",
-        "@parcel/runtime-browser-hmr": "2.0.0-nightly.214+52fd6741",
-        "@parcel/runtime-js": "2.0.0-nightly.214+52fd6741",
-        "@parcel/runtime-react-refresh": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-babel": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-coffeescript": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-css": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-graphql": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-html": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-inline-string": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-js": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-json": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-less": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-mdx": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/transformer-postcss": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-posthtml": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-pug": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-raw": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-react-refresh-babel": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-react-refresh-wrap": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-sass": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-stylus": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-sugarss": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-toml": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-typescript-types": "2.0.0-nightly.214+52fd6741",
-        "@parcel/transformer-yaml": "2.0.0-nightly.214+52fd6741"
+        "@parcel/bundler-default": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/namer-default": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/optimizer-cssnano": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/optimizer-data-url": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/optimizer-htmlnano": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/optimizer-terser": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/packager-css": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/packager-html": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/packager-js": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/packager-raw": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/packager-raw-url": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/packager-ts": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/reporter-bundle-analyzer": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/reporter-cli": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/reporter-dev-server": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/resolver-default": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/runtime-browser-hmr": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/runtime-js": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/runtime-react-refresh": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-babel": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-coffeescript": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-css": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-graphql": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-html": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-inline-string": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-js": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-json": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-jsonld": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/transformer-less": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-mdx": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/transformer-postcss": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-posthtml": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-pug": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-raw": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-react-refresh-babel": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-react-refresh-wrap": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-sass": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-stylus": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-sugarss": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-toml": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-typescript-types": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/transformer-yaml": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/core": {
-      "version": "2.0.0-nightly.212",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.0.0-nightly.212.tgz",
-      "integrity": "sha512-gBvXA6W83T7locoAvCcf8tVOmd9krlmLQfxSuTVKElqTokY2me/rksB8IC2q9w/HrNhYYdpU/pEtL5NiEGghOg==",
+      "version": "2.0.0-nightly.259",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.0.0-nightly.259.tgz",
+      "integrity": "sha512-6FEc2+1DQo1z9PJ9/VGgVgo9cjGp6Pcdue0538Nu40LdVkkCLhgHF/CuRkwW8de2c9p2fkKgyqzUG3Ci0+nnow==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.0.0-nightly.214+52fd6741",
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/events": "2.0.0-nightly.214+52fd6741",
-        "@parcel/fs": "2.0.0-nightly.214+52fd6741",
-        "@parcel/logger": "2.0.0-nightly.214+52fd6741",
-        "@parcel/package-manager": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/types": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
-        "@parcel/workers": "2.0.0-nightly.214+52fd6741",
+        "@parcel/cache": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/events": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/fs": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/package-manager": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/types": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/workers": "2.0.0-nightly.261+ab50b2f0",
         "abortcontroller-polyfill": "^1.1.9",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
@@ -1201,9 +1257,9 @@
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-H2W7moeP7Ir9uOSVBwp+qYx8Xr0HEVZAwfniuAdgvkBSUX1S51E6gMAmEHnXlF9izov5hBdNXKM3GXicsaIwww==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-goWtgH9HQeerDHA3A+3KGcvzA0j61q+xqvxdGjf9ks/Q5hGJYq6+mWAsbD2r+TxU/a1SzJtNU8kiXJwqz6o5sA==",
       "dev": true,
       "requires": {
         "json-source-map": "^0.6.1",
@@ -1211,20 +1267,20 @@
       }
     },
     "@parcel/events": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-+7l4ThUkAa5bWp5+761R1iEGGfeCWngJq+4EXAvekUnRBmoElfqitsK87D7RKIbl502CeC0D0kOEMnNs/rYsTg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-oMCXk9uEZycf5smMWUld5MHi7v0tTPOvkbq1i/6f1VYEDKldXYESVWNkAn13g9jkItXCn/VYumXuFoqqxO67ig==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-5ZvzY8GGneKR/GjuK/JmXna48SdtypJBcLoQZrcglO9PmuyFFhUYar9qWa4d9OgqGO2C0VDGHb5H7vhyXAOvNQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-cAK9d1Cy/vezXC/SqV3tg6UpZkoUZm2LG4qyvlFhq0BcsTvIeSWDtXP1OfbfjSt8BxdaOF59Wyb3/5UbKnKgMA==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "@parcel/watcher": "^2.0.0-alpha.5",
-        "@parcel/workers": "2.0.0-nightly.214+52fd6741",
+        "@parcel/workers": "2.0.0-nightly.261+ab50b2f0",
         "mkdirp": "^0.5.1",
         "ncp": "^2.0.0",
         "nullthrows": "^1.1.1",
@@ -1232,39 +1288,39 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-RxKLvRa9qe2M7fMZLK5HkPujpgqbijW0ptNNcyh2bl+n7ehnoBucfhuQkfPrWCW19ELAiVSt38Sf11oazFPUXw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-lzgzyLzkJrQfXYFX+Zqh8OJowbodbVEnw+vcBpvgcdC6hbgjDivaZUTM5WRVHNeXPLK8xE1+P3FgoSvnmzCljA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/events": "2.0.0-nightly.214+52fd6741"
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/events": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-ojCpCNNbxIkNGYc3Oqo6EWnov9vedLFzYTA5DJ5I0MoiCLdYePPRzVFWWWyRQSNJZB2I7w9AalZk6qxexAqP7Q==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-xrefA9tAfdKAyVZ3lRFc8rDrac5oTHYRxI3AEr+C27FTi6XIGyZH13S64qgztoh3nDvzub9+dvKit+SczLrXjw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-ZP1WrJ0aTRs+HdLVSk06QJX+CLY1P9A+LTjrOGbR/iM5J5FWXOeaqKNM6BqMDTIPepmVrLc/nnMrWvuNZhHzTA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-TgmKRgnoK06Wm+of+gfXxzXhLZaGK53ztWT4/Mt5CzpOAQhc+8YTofuqlxYUYasxCWjtfIVF+9RdYfFOy19UdQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-libs-browser": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-bgvneRZiWU6+zrEPn3oGKFHkrUV/uQBWKlGMPU1UIOzKJipOYv6AuNKA9rVaUmIwXRrF7vJRa/MuDhmvHc1yqQ==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-Yt/mtQFecQPw7ol1lYBKgrBvnIz1kgBqiWhqSOjRUvJw5DeaQlLqpl2Fl7EveEERCmH7KnmKqPdJI9XbLaLDag==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -1279,7 +1335,7 @@
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.0",
         "process": "^0.11.10",
-        "punycode": "^2.1.1",
+        "punycode": "^1.4.1",
         "querystring-es3": "^0.2.1",
         "readable-stream": "^3.6.0",
         "stream-http": "^3.1.0",
@@ -1287,47 +1343,27 @@
         "timers-browserify": "^2.0.11",
         "tty-browserify": "^0.0.1",
         "url": "^0.11.0",
-        "util": "^0.12.2",
+        "util": "^0.12.3",
         "vm-browserify": "^1.1.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
         }
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-LDDPsW9WcWV934154oQNa5BOOA4P1FT9oEx9nxx/zLJeSthfEfMqj2KNM1GJWyvB4Bem5tM7adC1p7ZbbOPczg==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-lC11a/AdBE7kc5JRDLRjxqeJk26K13H9Zlhc5LbNMOEsJpJBpigPWnX6RLqfI4Z69iUVI9NZIAWoZEb73nPDdA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/node-libs-browser": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/node-libs-browser": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "micromatch": "^3.0.4",
         "nullthrows": "^1.1.1"
       },
@@ -1438,59 +1474,60 @@
       }
     },
     "@parcel/optimizer-cssnano": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-qEdJWw5qZftEQWhKB41zrnjiXy6Kw3iYpx0TcPtxnOX/TQe9GKxAusiNoqH9utY512QK4c+6ASvuUkLV9BovCg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-gCHaI07b3253tdN2ePfpiQd4bwgcEc1yLy/LiQv7ezcEuBFR6Os9+TQ62kLO+TwqDSP0FN09UaMUuBeFQeQtcA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
         "cssnano": "^4.1.10",
         "postcss": "^7.0.5"
       }
     },
     "@parcel/optimizer-data-url": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-data-url/-/optimizer-data-url-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-JXBkJpFJQ/3ntoeIFEx8JRyneaQl43qA7lX26zTMETXAElJ9vxq63MV/hPIgD0ceNxrU6p14beNF3kQzGa0Jig==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-data-url/-/optimizer-data-url-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-TZTf58Ps7Ejh7c2OZfnZUuhSPjVNmRsvY4wXBNpZgjHsd/+I6FmPIbfUNBjC2/1QG8XZ25yOB2rCDRx07Y7prQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "isbinaryfile": "^4.0.2",
         "mime": "^2.4.4"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-xYg87KmycuJ+82UbobUoSPv+Pbb6a8D41kt/FH46ps1rXSJXRPH7gg9lE75GYf3ji0MKHni8zB3EyBVT7yA60A==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-h/DcgvvxSCGiM/PWWnLVcrozTBZt6fZYgCdTMlz0FzJOAwRXG+0rOeekp77INi/7og3a4jrRSqf36k6arGk9BQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "htmlnano": "^0.2.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-Kmzvstnc5eJIgFg2wHCXWD67PsIVRxnvZSFz4g/QDVzOoWWFUFzzZcT1wTn3FEsTNxnxkIiMNdEFtdyeeuO1Fw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-WCnycBuovVCaZd3Qg0nSVulnFtk+VH8pWQJvDQHGUi51Z3aYxBnkyj3tbjuF/APCnpCa2Te5lvlVV/FoCwdqcA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1",
         "terser": "^4.3.0"
       },
       "dependencies": {
         "terser": {
-          "version": "4.6.11",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
-          "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
+          "version": "4.6.13",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+          "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -1501,16 +1538,16 @@
       }
     },
     "@parcel/package-manager": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-1qVV4JBfbHUROEA6YhJAHFIUIb5ES+9+/0qkEq+aYEhNqICTp2EdtbZwmr+IhlI2UBe1psVbp2BhfOjtkKOuIQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-GzvqT2mP8TTwkIO8s6/RcYCLrnB58qTfXHNrX5Q7gKx0KFn5/VKvDuhty0mFcLY1P8qFHdgHJJbF/EpxVXwYRQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/fs": "2.0.0-nightly.214+52fd6741",
-        "@parcel/logger": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
-        "@parcel/workers": "2.0.0-nightly.214+52fd6741",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/fs": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/workers": "2.0.0-nightly.261+ab50b2f0",
         "command-exists": "^1.2.6",
         "cross-spawn": "^6.0.4",
         "nullthrows": "^1.1.1",
@@ -1520,90 +1557,102 @@
       }
     },
     "@parcel/packager-css": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-NcnP4szmg88CoChNq7VwsCCLQTYoqzlEiyCYMG5ccLhgly1NlPVp6V7ilUo6iLuafQ9KlXC58W5/7KQxRI9e+g==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-GZu5C6d+7FrvM7SGSXbkRxv1yuB6yT2yq/sNVlMK+WzTYMOPWQhR96T9aqZQPmBYak8kCU3S+QKPwWAPWL/Xbw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-DoQgeakgMRH1l5yx86SrUSGR7UsL0Nki4ecosV+Of4z2pU4UgPSWJ+Y1QcBNTVUE3zJwN5agussSWvjzCVW4NA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-Y6gAxlP+FfGbcpGDtQ8urXkE6pO1JmESvnV9nWHyW4ZW6pB29Q9XjMs/8KPs+pUka0VePKCjHjxitpWKG9uwVQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/types": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/types": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-b9k7PQSda7f9olW3fm9KHXI6bMDbyx9/7/DkF4wvrvms5PAZF2UGWdiALj9dXGQN15R7/VeGZAykRge3SBeOTg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-s6w85aHDBAgoexegTnVoGNXyTkdqZm0KhURQ3KXMoDtwKRBruluw6Y6aS7WP/cGPCS9xuBFWyHnTQ7ukHegNLw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/scope-hoisting": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/scope-hoisting": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-zqqlTo/jRJKKeeM7DTiw9odWtZ1dpsE243UrkI6c3Q4NePAUgHdV2BT9m7WiDZkEwL8lnYjq+wsONsqjDl/axQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-LxLcNCM5fQFp5WbMydQP7CiL6GAdTvbPZLmd7rBONPtlneB0auIVn2A9b0fudam9MDm5pCMFkg9hfgEeDuY3xg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
+      }
+    },
+    "@parcel/packager-raw-url": {
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw-url/-/packager-raw-url-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-RtBoSlMpqcQkuhzlx/8S3cabJxaO9qlHM9SqOYwTeISP2qCVcgwHpzDU5q+6PmP33iFyI+PJemd31amBv0MS3g==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/packager-ts": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-e53b+XcDtxGvIQDf4Eu0hK0Kky0DWcBkM4qnCq/eOsn1RbrPLLW3d1Y9007edbGzL9DTD3dOkHMfmhBtrzTUVQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-oIWQSVSbNae5m/Z0o2fZb6xG/yluvbCmyjkzyphn//1XbFh+9fNp0Bai7A56NWeyr1v/W0hA0UF8OkdYj09U0A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/plugin": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-oQNuJSg2zTHAD+AQ3nVO9AEswa1YlswRHZo/ti1rxgyBbsH72zL2QEBrle8/lQdHedbkeZyPF7ZMxH1sQa5fSg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-t8RkCS2AGv7dibf1M6F5R4x4VCrcLIR3lERu/4n/05s6agy16si/KAQZRfvST4ffloN2w3tdFA68h/VGnGknGQ==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.0.0-nightly.214+52fd6741"
+        "@parcel/types": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/reporter-bundle-analyzer": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-oTH6bLxhC301oO/fsyiWLpDlv/33PA2WiFJ2Z4j3TrCtrbIvAZamH8RKGxqMEUfoFQv0HSOSMHSZkSI19m9/0Q==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-S8ealZD2yTQHaH/k+3iSwYJMkUtk9QRE6/mkxZX8bxuJMiozuIJl1s4wxLdWOAwaOJj4g3Q26rea+vLQOXauhQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-+WCJcM3zza8PeC5O0bZYS5HjUrUslXMly6J9rJplx6sPcqirIuThqFn6SFFU5M+sp1hxnniE+KA0YsUc2vOk2Q==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-7Nm7LJ9R/PeFJ37/qRTRUW/kDzQE6HCs8PaPHqNT2hh4cz1vftSuixNZz2DwPcIMR4JGC4RDBwLIOfpgBAD8Ig==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/types": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/types": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "chalk": "^3.0.0",
         "filesize": "^3.6.0",
+        "nullthrows": "^1.1.1",
         "ora": "^4.0.3",
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1701,13 +1750,13 @@
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-cs7XajP0MMGBGl1WPm8CJcLbcvyjnb/9IYdfz29h7kBIfCSpyHwrawzDZ60KcyA/Rk85LY/P+4m8WPOZB2FJBA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-DVpoDjUDmPi+a71g1jhIrbJNj1gVT9NrKVXOJLJv9Tbd2UOyQfL6j4oqGGZg8e8bYVf/6VE42h3T2V4IjAU69A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "connect": "^3.7.0",
         "ejs": "^2.6.1",
         "http-proxy-middleware": "^0.19.1",
@@ -1717,50 +1766,50 @@
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-VKLcHo9vsnicwZfgosLBEdQMOs/A+XZssKzVeXJX+rNaJWwe55BQNUhzlABCki/taZe4kKxRLdFh/fRa8/WkqQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-D8O8bU6DMbp8SWZNQQ5KjsY6dL/9VPDP6FboUTsNNhcr6YcGPLf5QJE4GdOmb/1xEe846Ifh5duR8DjTRzLjNw==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/node-resolver-core": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-Z1m8mVtDAcSSeDYelqYIePR1VF5E9rHemskEWtcmhs3ktrzgsfmEZtfZYKyAy9BGf7SBFWDms8o4/7MMhiZziw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-KlYiqhd9Yf07g3PSi6OwV4IdmRzRUYQKigpBxuuahH4xy9F9+aAI49Pyo9AkrPJIBz9c6h6FqZE/HW54ccEfFw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-P6lL6JcI4lClJl9wQeT4YazrE5TQsJyR8laz+A0IEBd/GCRDFMu3cseCZuEcmW+u8DOgVoOtypEUuy4NpLozhA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-drjOoyq3DWLDK+V4znObPUolgWay6dNRXsMvmFkVWvHqXPa9nfW6jLW/vrH92DYZD7s+brgOhndGhNH8bQYq0Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-aaYR+IjqrqAkpwkgXwGRA+7x69Z1sy2HE4FinOfCil/En/hWIScSB2NGHSUGhTbcvqGtXq2WO3l6x2kDj337jg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-HZyeA7pIoIDZoDOKxCpLQQSzSGvUNUqYH0BYtumLK7cMRjSClmTVj0D4RuM1IUDTolcrUftBYHzG0vdu+qNtog==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "react-refresh": "^0.6.0"
       }
     },
     "@parcel/scope-hoisting": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/scope-hoisting/-/scope-hoisting-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-bV86GJ3yN6LrNKMHGvVxYMvsU2vnK3leodA1BTIXwhYcKP5PMnLY4V3infAsiZ7teORUjPq41DC+Qd83ODyvdw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/scope-hoisting/-/scope-hoisting-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-0jchYL77RLgHLiDg+i5B54qwUIZPvarGcUR+zqWyCYHK2hrXuYDyQ3f8yPAHkszEGmSXR7bSw1rjr5pEzk2JFg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.3.3",
@@ -1768,10 +1817,10 @@
         "@babel/template": "^7.2.2",
         "@babel/traverse": "^7.2.3",
         "@babel/types": "^7.3.3",
-        "@parcel/babylon-walk": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/babylon-walk": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
@@ -1786,23 +1835,23 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-IV5vHWB+4ZrHcp5SoSJVfJyRwiv/S+JflvHWps3YBaYSrcDQGOSWQwOtYcp/1VMH+Em5Ot+esJawwFIh7GKx7w==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-vyFxn2qkUojuI1zOZPbiA/tW4JiDe2F8yhZDV+ShjwJ/j38Azu+0DS8tz3s0XQRVhCggLdnmgD7M05FZFa6WgA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/generator": "^7.0.0",
         "@babel/helper-compilation-targets": "^7.8.4",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-typescript": "^7.4.5",
         "@babel/preset-env": "^7.0.0",
+        "@babel/preset-react": "^7.0.0",
         "@babel/traverse": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/babel-preset-env": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/babel-preset-env": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "browserslist": "^4.6.6",
         "core-js": "^3.2.1",
         "nullthrows": "^1.1.1",
@@ -1818,27 +1867,28 @@
       }
     },
     "@parcel/transformer-coffeescript": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-z3hdpS5YZxKj2EJjoVnDDxsh+YoOhE/Ifx0V5q5PQUVu3PhuWp1EBI818d2bWfzqYKTK0s0Nw25YlMzwIiW9LQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-mf1UAN8nnd3ZuG+kdMKgiORe7xFHpg+LSAwmk2Rs40HuLMe84CN/G5FI/0sQ/KttE0biROoUNMOZ4pj0DtdHFg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "coffeescript": "^2.0.3",
         "nullthrows": "^1.1.1",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-BSiWGhox0vwTzOxIw0fefql//B+tStW/C2NT3wOZSMRqGxc6XHBFv309B+LFA3Mo8LcMRhm3xGQjgNr4GHItog==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-kMX5wZcblcZj5CgWOOKlrkGmnLPh13YP3D1dPNHFpPqt1ywgoOe6DlE/5lEjOqHXp0lW07mdgUuh6KgkWanboQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "postcss": "^7.0.5",
         "postcss-value-parser": "^3.3.1",
         "semver": "^5.4.1"
@@ -1853,22 +1903,22 @@
       }
     },
     "@parcel/transformer-graphql": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-graphql/-/transformer-graphql-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-8psi3KMpLYeJ+EKqdNkD6gAm4o6KlqflmDyOWeVBFcmQBjMGjvV66ju/1inA8gkPj9OX5HUkz+MO1JiEUTdObA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-graphql/-/transformer-graphql-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-Z/mmdKCMHnAVoTX/pnSj6TfiAFPdAIg3ZINKZ/hhC3n/OljgXepRxGlIacSsrY27YGC/ReJ/XgObW/VjsIqgWA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-go6a0QIJUqPjdyXyMDI4YJoW1fIq+gWN4kAkSldf9HGW51a1sYaglhs1D9fpv18TKq4gs9kHO+Wgq6GnEg4Z5w==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-z01pOwHHVvp3uA4Lz7SXusFBtXlGjdwty/Tg9AngMAXQSEdcnZa/smY2StJO+qDiL0bKsLaKTF1HZUREXtKrxw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3",
         "posthtml-parser": "^0.4.1",
@@ -1877,18 +1927,18 @@
       }
     },
     "@parcel/transformer-inline-string": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-vovxDj7iiYgDk+Lq/k4dRGBI7zmhHivymgJvuXBEZd/8n2j5dRrvNMwzhBZGXGKT3/Fa7248SaRp1OEIqiY9GQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-sGL8FPFaWxA45nVUF2f3qOBHYYrJnjsJxPmtsgqodm4GGWh/ypSqs5fpwNV2gYPfYE8zB0PqfOb1xu7MlCxL3Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-7QGJr1uGygVC7vO0EyaUC9XB1zO32xpD9/5JRnZ99AZe00bifYoIB2vudZysBqCxKSeeQoe+Amdfx1z3dRl3Ew==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-mWIVZHtDX9SJqbs9FqNrkW/YjD2s5Xa3eIp6FsY79tEGW/r2Cvf2k5PgBqPXemikP8NIfBOOxHcfV4r3g+vlJg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
@@ -1898,23 +1948,23 @@
         "@babel/template": "^7.0.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/babylon-walk": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/scope-hoisting": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/babylon-walk": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/scope-hoisting": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-g3cETI0haP7qrsSgIEnVs2WYelkVuYCk7NcZxe34Cl9A2P+fke52/lu5IVKZ3BLL98bI5dQ/9fGXLBLmluES6A==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-kU6MYHDUp7BaW9i8H9izc9pY2Fd9JsokwGmERpX+ZnVUUIrjxe91FpTFK+8YBYVjM89qCNKILN4NoN68QxHXew==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "json5": "^2.1.0"
       },
       "dependencies": {
@@ -1929,32 +1979,55 @@
         }
       }
     },
-    "@parcel/transformer-less": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-less/-/transformer-less-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-tEfOSnLaTITRe/iYords8Ao43WYu8ZVmQ4klEGc1bhS2tscWMhRsotA8mkitXGl6FPYbE6Y0vCqnrD3iolGasw==",
+    "@parcel/transformer-jsonld": {
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-jsonld/-/transformer-jsonld-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-odEqEh87byyk9kD+k1OBabyFoubz1tZt+w5XQtroV/a6n0Ay6cXzsaI8cI+meAgNKK3PSHc1ImoYwNeutpvnGQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/types": "2.0.0-nightly.261+ab50b2f0",
+        "json5": "^2.1.2"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-less": {
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-less/-/transformer-less-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-xOkx8V4BQqXYE2DIvj6GM1JRtKaKfuPgyRHCVucFTn72XWoPhiGFbCgCfzYaSa+UxgZBdtb2KOtgB/dd3ELVTA==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9"
       }
     },
     "@parcel/transformer-mdx": {
-      "version": "2.0.0-nightly.1836",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-mdx/-/transformer-mdx-2.0.0-nightly.1836.tgz",
-      "integrity": "sha512-4YDZVDyHvNDHifWkHDAabc7RnS9OzhY5Y+KGG7uQgKIZCI6ShyQmUuLNsIfraqwokGl2XQF6B0mXWln2p5an4A==",
+      "version": "2.0.0-nightly.1883",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-mdx/-/transformer-mdx-2.0.0-nightly.1883.tgz",
+      "integrity": "sha512-6S5nM4CAWdRuvxWGGK3abcQL/yyfuFpAd9A1EnsRhNF6Mq57JKcf4ahRrVGOa4D+QnR3D0CDec3rrxaUWtwKZg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-dOPqf89d/7iuZsKHtDlCIMlKzE4Uv/j64OQZRJb6mYZiKQ+1oGAaKBrniFl/m/q4lyoul9Vl4BgEVVNjymSLew==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-HSH5CdSm+kLE86f9WbHtFuVNJlz1ufTo0+iA/8JcJIX0mtMFu/8ZgUQyU4/iAZcVG4lElurIXCRQ0oFCK07tyg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "css-modules-loader-core": "^1.1.0",
         "nullthrows": "^1.1.1",
         "postcss": "^7.0.5",
@@ -1971,12 +2044,12 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-FIqNXih+gMuLYB/p43flm07dDQf7u8dWvAbVXejhP0bSpUr3jtbwVv5wzStb1h1YeHorU6HvVOrZN9A1dN+5cg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-rnSW3Hgl9ujhHfREuYXSDjZGHA+38NNMfAGWs6lnnWAZXnclMSYhopWVX2fwLtBsb4K17tsCMbIVoLyGVtuxkg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3",
         "posthtml-parser": "^0.4.1",
@@ -1985,137 +2058,139 @@
       }
     },
     "@parcel/transformer-pug": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-pug/-/transformer-pug-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-cfNMKOe2fqFgy0rPNPGK3wVTbypIjdBnJ7YwR7ez2QksYa6f/m9WT24A6lrYkDGpmers6e3mgstZQggXRONaqg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-pug/-/transformer-pug-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-5oTUaz0eUS0s043MVaVEycxJ7ca+3LZzUHFS+S1sdo8dfsCs2ps9pD9KtsyvGT66b7YO1ZXx/fWiX4AN7Y4fCQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-CUtE3W6ANhmJmYewU78V4eSjysMmwFrjZHWGstj69v+PBmAGLudxJTa+MF6NPgXdLGmdH1+HZ+L4v3H3clUYbg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-V6EzZN4Q224cf1pGMc9rNrGC0k596K/aSEg1r1SX2TboU6XBdA3dSuBarW6MCnILpcn7kILWJ10xMMdDFgYFDQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-react-refresh-babel": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-babel/-/transformer-react-refresh-babel-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-1ENF7MHZweFf6Dumo6FCgk2BllY8v4lSM9hnQBdqrIVzY0Z3hAJnZz7bedua534Gh4ssBZMsJRLNtlpPh0DKrg==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-babel/-/transformer-react-refresh-babel-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-iup4y0CTzHZ+Q0L6+XGuHDiHSIxyDsYBUQ+POZfdnX+L1wKifqmtS255kla6ezAQLdKPAZh4B8AgalwmNgxnug==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "react-refresh": "^0.6.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-ECZht3+HZJKcaTapHZ9xKW2Yvt2/ZDF4Ja+A4hw8Qdv7wIE1GZXGVU/YinIzt2DQ6IM7rUk6uk0SwofPotGBpw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-GeFl9G0D+QWJqFXWAeAJ/l0ERe4QFPoCm5Vi/YbGcuYw1cPppAy2rYDstEnqbgPVNwUu2RHjx453UKctTr/gdg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/template": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-nightly.1836+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.1883+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "react-refresh": "^0.6.0",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-sass": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-/gHVqK7Qm91B4HDguSEIU6mf4h1w8aJYT+8V3k+vRvIu7sq+nMEafvEHVBf+eUJC44VxNo8rOFpGwNdd4eEUJQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-ODQnCFSIdlmWRp42rZ+OO7tkX91dAoap8aeiIDsCRDyO1O1umoJXPQfbfk7k4LYItssLAy7eUPG0qYlJcaV9yg==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.0.0-nightly.214+52fd6741",
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/fs": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-stylus": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-stylus/-/transformer-stylus-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-KaDGBzL11xc2iCOfMBWBSma3vaqbj6gwY4iEIS+yyHyk90iloVdI53k2AS+5wY8VlMDpDd+cmmnAbVexBKFAbQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-stylus/-/transformer-stylus-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-dc2ft3hftDkbHarH0r6vtJ9aOw11o9f+sfpJhnmE9JupPTfCO/cGlF8fBLmIG+nMGGumTIhCjF5Ewif5v1qnWQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-sugarss": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sugarss/-/transformer-sugarss-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-7Zggl4FyXlSsOvuBvSdcRNJkzgTeBUCsAlBkZa4Lz6Nl/JIhgZGKD1VZWPAoCptPoDX8zRk/P6t/6zxRgnCO4g==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sugarss/-/transformer-sugarss-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-lBR1FfljeWnpFOU/S4BQsfqGyy3ofuJexOqdHeLQD/uFIGS1a7o6FU2UktbGK3bhIrKWN1EvRPlJtw5QuufVyQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
         "postcss": "^7.0.5"
       }
     },
     "@parcel/transformer-toml": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-toml/-/transformer-toml-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-NJEpWjZXsdgGIjc1MXfOCehVkxXhxz5bK3UwKHs1auBO+m+b5vOQSyfMcM7gVSDzxzFAyA70WC91gsZ2hVJC0g==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-toml/-/transformer-toml-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-wxKKV58tcDcMAvRZWlKXGV9mfZwWXlV7dOzPD3+ixdcSxT1E4+SzDIong7K6t5vOnkAD16PawmLXt6D9TXy5Yw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/transformer-typescript-types": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-v3lyafGjrExf/FIqtSTwBWOGjkN7Z6T/pjMosH5+NUj36tnxim8DGRVtMVnzzqD70yeHwdoNBHnQ7WMx7UxqKw==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-3RBWrejZfYls3SbLCBy5eMEvGB6piMMBsipg4yNWap6HQGibiGiei1VrKiEtIjADd4AXuz6wPy+uFp6ODsgdcA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741",
-        "@parcel/source-map": "^2.0.0-alpha.4.9",
-        "@parcel/ts-utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
+        "@parcel/ts-utils": "2.0.0-nightly.261+ab50b2f0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-yaml": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-yaml/-/transformer-yaml-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-qZL2Lt8UEHYov8j3BUHOgQgIlhzvicI4fLBU/4BdwnD/fLxqDnWQzYcQYzU0VaMYq77gK2dLm/CTp/gzqBBqiQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-yaml/-/transformer-yaml-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-3/5xFcH9q8tZT04MPUt0kGmDq7XWs7DLlrwz+7aTCo1u3rLNOeSJTDUKWqQ86qCyt9KPMbLkyBNnKz1kmyXZ3A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.214+52fd6741"
+        "@parcel/plugin": "2.0.0-nightly.261+ab50b2f0"
       }
     },
     "@parcel/ts-utils": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-nR29JebSrTr/w9M1ZEVnRxblutG2DXVXSuVXfoYW5na+nnAfORaDJHoq8MpTeViQlmAlBTow3wgTZdEk0PIlVQ==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-0fu7YgIriEUy4qA051KrORDMJ035JjHHYb/rkYRTbsVTmqfjMRxhUR/P5GS8su08pFoSQTvGmDAUBqzg6YWKYA==",
       "dev": true,
       "requires": {
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/types": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-MUZM7BoIB660TbEq2WLGWknJd0N2laJevNxdTBarvHgkubPRiXNwsb0048vjWLnUoWSLsRnaB2ZvDDgi9/WqtA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-GmqNECwo+o8KfeehSgoJAjDxEDDG9z2DbKA85Tj5TSEoFdZ6D9Y5Myq7OS2prcJlJ4Cdmxow5u8ZXmOEkddRLw==",
       "dev": true
     },
     "@parcel/utils": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-4UrVB72ddlWgdwPDoBedq+e805j2LCMfZ70tt9q1XSWohapg1LXJd+6j7PjNZbzxo33Mtun2gga8gdlzYAKvBA==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-y6E8O3Lru1JKr/gIg4gA0zVDIL3mdePHI0A9r9QQSkz4o3pbajfvB0mRMuFfUo64IvT7wCcKFAItuAVSJCurkw==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.0",
-        "@parcel/codeframe": "2.0.0-nightly.214+52fd6741",
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/logger": "2.0.0-nightly.214+52fd6741",
-        "@parcel/markdown-ansi": "2.0.0-nightly.214+52fd6741",
+        "@parcel/codeframe": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/markdown-ansi": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/source-map": "2.0.0-alpha.4.9",
         "ansi-html": "^0.0.7",
         "chalk": "^2.4.2",
         "clone": "^2.1.1",
@@ -2152,14 +2227,14 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.0.0-nightly.214",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-nightly.214.tgz",
-      "integrity": "sha512-xxNU7J+HbpjGNrl4c18Uq3F1ODEBR7UTJ/5G9/jGlLIP1tjPGHSkjTGOQAFWo9cSpiFUVdHN+KNCdjwXQHej1Q==",
+      "version": "2.0.0-nightly.261",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-nightly.261.tgz",
+      "integrity": "sha512-oBdfAAKed2ASUvhP04N3E8/Co2PemDM+BR+KUOZjZCPjBbNIXou4KhkS3+EDoY/Rcb5MIDqZCyib28yVdx3N6g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-nightly.214+52fd6741",
-        "@parcel/logger": "2.0.0-nightly.214+52fd6741",
-        "@parcel/utils": "2.0.0-nightly.214+52fd6741",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
@@ -2211,9 +2286,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2275,6 +2350,38 @@
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "argparse": {
@@ -2310,6 +2417,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -2319,8 +2432,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -2340,6 +2452,14 @@
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "assert": {
@@ -2384,6 +2504,15 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2397,9 +2526,9 @@
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
@@ -2499,19 +2628,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "bluebird": {
@@ -2521,9 +2637,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
       "dev": true
     },
     "boolbase": {
@@ -2608,21 +2724,30 @@
       "requires": {
         "bn.js": "^4.1.0",
         "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
+      "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0"
       }
     },
     "browserify-zlib": {
@@ -2635,21 +2760,21 @@
       }
     },
     "browserslist": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+      "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001038",
-        "electron-to-chromium": "^1.3.390",
+        "caniuse-lite": "^1.0.30001043",
+        "electron-to-chromium": "^1.3.413",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
       }
     },
     "buffer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -2762,9 +2887,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001041",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz",
-      "integrity": "sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA==",
+      "version": "1.0.30001054",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001054.tgz",
+      "integrity": "sha512-jiKlTI6Ur8Kjfj8z0muGrV6FscpRvefcQVPSuMuXnvRCfExU7zlVLNjmOz1TnurWgUrAY7MMmjyy+uTgIl1XHw==",
       "dev": true
     },
     "caseless": {
@@ -2833,12 +2958,12 @@
       }
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-spinners": {
@@ -2942,9 +3067,9 @@
       }
     },
     "command-exists": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true
     },
     "commander": {
@@ -2975,6 +3100,38 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "connect": {
@@ -3031,6 +3188,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "copy-concurrently": {
@@ -3056,8 +3221,7 @@
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-      "dev": true
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -3103,6 +3267,14 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "create-hash": {
@@ -3136,7 +3308,6 @@
       "version": "15.6.3",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
@@ -3623,6 +3794,14 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "dom-serializer": {
@@ -3714,6 +3893,38 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "ecc-jsbn": {
@@ -3739,9 +3950,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.405",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.405.tgz",
-      "integrity": "sha512-D+xkP+hAQY/790DzImC8bI8QJLaArNG4b74bYvkhkK/fli51JmNyUYxwKLSl/8VPGkkXEqKCupSDD05/E5P72w==",
+      "version": "1.3.432",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.432.tgz",
+      "integrity": "sha512-/GdNhXyLP5Yl2322CUX/+Xi8NhdHBqL6lD9VJVKjH6CjoPGakvwZ5CpKgj/oOlbzuWWjOvMjDw1bBuAIRCNTlw==",
       "dev": true
     },
     "elliptic": {
@@ -3757,6 +3968,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
@@ -3786,7 +4005,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -3801,9 +4019,9 @@
       }
     },
     "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
       "dev": true
     },
     "env-paths": {
@@ -4201,7 +4419,6 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -4288,6 +4505,38 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "follow-redirects": {
@@ -4314,6 +4563,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
@@ -4356,6 +4611,38 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fs-constants": {
@@ -4383,6 +4670,38 @@
         "iferr": "^0.1.5",
         "imurmurhash": "^0.1.4",
         "readable-stream": "1 || 2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -4528,9 +4847,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "har-schema": {
@@ -4646,13 +4965,14 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       }
     },
     "hash.js": {
@@ -4738,19 +5058,19 @@
       },
       "dependencies": {
         "posthtml": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.12.1.tgz",
-          "integrity": "sha512-uP+fqiowLFQaZ9WooFpsm56+lu6enrMPPIl3rNuQsmJlFGAFvA2mtGDu1NyZCEOYMGxZiWWzGK+Vosp9VIBouQ==",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.12.3.tgz",
+          "integrity": "sha512-Fbpi95+JJyR0tqU7pUy1zTSQFjAsluuwB9pJ1h0jtnGk7n/O2TBtP5nDl9rV0JVACjQ1Lm5wSp4ppChr8u3MhA==",
           "dev": true,
           "requires": {
             "posthtml-parser": "^0.4.2",
-            "posthtml-render": "^1.2.1"
+            "posthtml-render": "^1.2.2"
           }
         },
         "terser": {
-          "version": "4.6.11",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
-          "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
+          "version": "4.6.13",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+          "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -4779,17 +5099,6 @@
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
           "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
           "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
         }
       }
     },
@@ -4942,7 +5251,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -5235,8 +5543,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-svg": {
       "version": "3.0.0",
@@ -5253,6 +5560,18 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
     },
@@ -5302,7 +5621,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -5323,8 +5641,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -5522,13 +5839,48 @@
         "ansi-escapes": "^3.2.0",
         "cli-cursor": "^2.1.0",
         "wrap-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
       }
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -5614,27 +5966,35 @@
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "dev": true,
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -5744,9 +6104,9 @@
       }
     },
     "mkdirp-classic": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "move-concurrently": {
@@ -5813,9 +6173,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -5831,7 +6191,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -5844,15 +6203,15 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-      "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
-      "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
+      "version": "1.1.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.55.tgz",
+      "integrity": "sha512-H3R3YR/8TjT5WPin/wOoHOUPHgvj8leuU/Keta/rwelEQN9pA/S2Dx8/se4pZ2LBxSd0nAGzsNzhqwa77v7F1w==",
       "dev": true
     },
     "noop-logger": {
@@ -5938,8 +6297,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5979,10 +6337,14 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -6084,9 +6446,9 @@
       }
     },
     "ora": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
-      "integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
+      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
@@ -6125,15 +6487,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6154,16 +6507,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -6236,19 +6579,53 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "parcel": {
-      "version": "2.0.0-alpha.3.1",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.0.0-alpha.3.1.tgz",
-      "integrity": "sha512-/j6L9OQKkiYTDnCAODFUYMkZYTraGqXksnGPRcdSFCQO3Mponr/gCHv9qZpVJmACPcM6JIjFKWyqoH+yjT7LKg==",
+      "version": "2.0.0-nightly.259",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.0.0-nightly.259.tgz",
+      "integrity": "sha512-zQaZWfzoyrRnSCljJDUIbUhkRPEvysfNMMef61+SN1ezXN+XykZFdKKKA6mACRY2/gO+GMQoJ4E5JsLx9OqgeQ==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "^2.0.0-alpha.3.1",
-        "@parcel/core": "^2.0.0-alpha.3.1",
-        "@parcel/fs": "^2.0.0-alpha.3.1",
-        "@parcel/logger": "^2.0.0-alpha.3.1",
-        "@parcel/package-manager": "^2.0.0-alpha.3.1",
+        "@parcel/config-default": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/core": "2.0.0-nightly.259+ab50b2f0",
+        "@parcel/diagnostic": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/fs": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/logger": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/package-manager": "2.0.0-nightly.261+ab50b2f0",
+        "@parcel/utils": "2.0.0-nightly.261+ab50b2f0",
         "chalk": "^2.1.0",
         "commander": "^2.19.0",
         "get-port": "^4.2.0",
@@ -6375,9 +6752,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.29.tgz",
+      "integrity": "sha512-ba0ApvR3LxGvRMMiUa9n0WR4HjzcYm7tS+ht4/2Nd0NLtHpPIH77fuB9Xh1/yJVz9O/E/95Y/dn8ygWsyffXtw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -6962,9 +7339,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-      "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
     "posthtml": {
@@ -6987,9 +7364,9 @@
       }
     },
     "posthtml-render": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.2.1.tgz",
-      "integrity": "sha512-5FU96lBesmRwczhmdR9p3ZgK0xJtpSSXbjabowHr26adCLB7tZVhOV31k48xjALeAKRcexvczkNdl+Wn7FRjeQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.2.2.tgz",
+      "integrity": "sha512-MbIXTWwAfJ9qET6Zl29UNwJcDJEEz9Zkr5oDhiujitJa7YBJwEpbkX2cmuklCDxubTMoRWpid3q8DrSyGnUUzQ==",
       "dev": true
     },
     "prebuild-install": {
@@ -7043,7 +7420,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -7058,7 +7434,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7083,6 +7458,14 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        }
       }
     },
     "pump": {
@@ -7240,7 +7623,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7251,7 +7633,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7262,8 +7643,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-refresh": {
       "version": "0.6.0",
@@ -7272,18 +7652,14 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "regenerate": {
@@ -7443,9 +7819,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -7464,30 +7840,13 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        }
       }
     },
     "ret": {
@@ -7549,9 +7908,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
     "safe-regex": {
@@ -7566,8 +7925,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -7588,7 +7946,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -7638,8 +7995,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -7854,9 +8210,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -7870,9 +8226,9 @@
       "dev": true
     },
     "spago": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/spago/-/spago-0.14.0.tgz",
-      "integrity": "sha512-nQMbxZkj5a9c1j36aUd7dp2BhlSByFkfu7/I4bA4nAnL39IAsoxz/p9B6FFs/TKCDcoaWjjjIvnOmei9G4j8SA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/spago/-/spago-0.15.2.tgz",
+      "integrity": "sha512-RaH7AaY8Dzb9uhzDdhN5fMXAYQm5/Js7Qnb7M9NgbapV29dS7gMy7vQ6i6FAoLEqzbvBDzbSjQ+VabLQmaGbEQ==",
       "dev": true,
       "requires": {
         "request": "^2.88.0",
@@ -7895,19 +8251,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "sprintf-js": {
@@ -7992,28 +8335,15 @@
       }
     },
     "stream-http": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
-      "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+      "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
       }
     },
     "stream-shift": {
@@ -8031,23 +8361,6 @@
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "string.prototype.trimend": {
@@ -8093,12 +8406,12 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -8220,19 +8533,6 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "term-size": {
@@ -8260,6 +8560,38 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "timers-browserify": {
@@ -8327,14 +8659,12 @@
     "todomvc-app-css": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.3.0.tgz",
-      "integrity": "sha512-RG8hxqoVn8Be3wxyuyHfOSAXiY1Z0N+PYQOe/jxzy3wpU1Obfwd1RF1i/fz/fR+MrYL+Q+BdrUt8SsXdtR7Oow==",
-      "dev": true
+      "integrity": "sha512-RG8hxqoVn8Be3wxyuyHfOSAXiY1Z0N+PYQOe/jxzy3wpU1Obfwd1RF1i/fz/fR+MrYL+Q+BdrUt8SsXdtR7Oow=="
     },
     "todomvc-common": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/todomvc-common/-/todomvc-common-1.0.5.tgz",
-      "integrity": "sha512-D8kEJmxVMQIWwztEdH+WeiAfXRbbSCpgXq4NkYi+gduJ2tr8CNq7sYLfJvjpQ10KD9QxJwig57rvMbV2QAESwQ==",
-      "dev": true
+      "integrity": "sha512-D8kEJmxVMQIWwztEdH+WeiAfXRbbSCpgXq4NkYi+gduJ2tr8CNq7sYLfJvjpQ10KD9QxJwig57rvMbV2QAESwQ=="
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -8356,9 +8686,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
       "dev": true
     },
     "tty-browserify": {
@@ -8400,8 +8730,7 @@
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-      "dev": true
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uncss": {
       "version": "0.17.3",
@@ -8590,15 +8919,17 @@
       "dev": true
     },
     "util": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
-      "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
-        "safe-buffer": "^5.1.2"
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {
@@ -8707,8 +9038,7 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-      "dev": true
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -8747,6 +9077,20 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",
@@ -8799,23 +9143,6 @@
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
         "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -2,25 +2,27 @@
   "name": "purescript-react-basic-todomvc",
   "version": "1.0.0",
   "description": "TodoMVC with purescript-react-basic",
-  "main": "index.html",
+  "main": "dist/index.html",
   "repository": "https://github.com/f-f/purescript-react-basic-todomvc",
   "author": "Fabrizio Ferrai <fabrizio.ferrai@gmail.com>",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "create-react-class": "^15.6.3",
-    "parcel": "2.0.0-alpha.3.1",
-    "purescript": "^0.13.6",
-    "spago": "^0.14.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "todomvc-app-css": "^2.1.2",
     "todomvc-common": "^1.0.5"
   },
+  "devDependencies": {
+    "parcel": "^2.0.0-nightly.259",
+    "purescript": "^0.13.6",
+    "spago": "^0.15.2"
+  },
   "scripts": {
-    "start": "parcel index.html",
+    "start": "npm run build && parcel index.html",
     "test": "echo \"Error: no test specified\" && exit 1",
     "install": "spago install",
-    "build-production": "spago build && parcel build index.html",
+    "build-production": "npm run build && parcel build index.html",
     "build": "spago build",
     "clean": "rm -rf .cache .spago .psci_modules node_modules output dist"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "install": "spago install",
     "build-production": "npm run build && parcel build index.html",
-    "build": "spago build",
-    "clean": "rm -rf .cache .spago .psci_modules node_modules output dist"
+    "build": "spago build --purs-args '--codegen js,corefn' && zephyr Todo.App.app --dce-foreign",
+    "clean": "rm -rf .cache .spago .psci_modules node_modules output dce-output dist"
   }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,4 +1,4 @@
-{ sources = [ "src/**/*.purs", "test/**/*.purs" ]
+{ sources = [ "src/**/*.purs" ]
 , name = "purescript-react-basic-todomvc"
 , dependencies =
   [ "effect"


### PR DESCRIPTION
Sharing this three-line change to show how to achieve smaller bundles.
This shouldn't be merged since zephyr binary needs to be installed manually.

Production js bundle shrunk from 439 to 184 KB.
Gzipped sizes shrunk from 103 to 56 KB.

Using Zephyr 0.2.2
https://github.com/coot/zephyr/releases